### PR TITLE
Makes RPM filename from package config instead of project

### DIFF
--- a/src/leiningen/rpm.clj
+++ b/src/leiningen/rpm.clj
@@ -11,8 +11,8 @@
 (def username (System/getProperty "user.name"))
 
 (defn- rpm-path
-  [project]
-  (str "target/" (:name project) "-" (:version project) ".rpm"))
+  [package-name package-version]
+  (str "target/" package-name "-" package-version ".rpm"))
 
 (defn- create-directories
   [builder dirs]
@@ -85,10 +85,10 @@
 (defn rpm
   "Java based RPM generator"
   [{:keys [license description url version root rpm] :as project} & args]
-  (let [filepath (rpm-path project)
+  (let [package-version (:version rpm version)
+        filepath (rpm-path (:package-name rpm) package-version)
         f (file filepath)
         file-channel (.getChannel (RandomAccessFile. f "rw"))
-        package-version (:version rpm version)
         pre-install-script (file (:pre-install-script rpm))
         post-install-script (file (:post-install-script rpm))
         pre-uninstall-script (file (:pre-uninstall-script rpm))


### PR DESCRIPTION
Previously rpm-path was made from variables defined on project level

```
(str "target/" (:name project) "-" (:version project) ".rpm"))
```

Meanwhile version used in package metadata is defined in :rpm section of
project with fallback on project version

```
package-version (:version rpm version)
```

Which means version in filename can get out of sync with version in rpm
metadata.
This commit makes both name and version components of rpm filename to be
sourced from :rpm section.
