### PR TITLE
Minor improvements.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,6 @@
   :url "https://github.com/pausebreak/lein-redline-rpm"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.redline-rpm/redline "1.2.2"]]
+  :dependencies [[org.redline-rpm/redline "1.2.4"]
+                 [org.apache.commons/commons-compress "1.18"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
We started to use `lein-redline-rpm` to build a RPM for one of our projects and added some minor improvements regarding `SNAPSHOT` versions and third-party dependencies.